### PR TITLE
Propose a move to the newly created market category

### DIFF
--- a/ROBOT.md
+++ b/ROBOT.md
@@ -1,5 +1,5 @@
 {
 "ModerationLevel": "communityManaged",
 "Facilitator": "Dag83",
-"Category": "maslow"
+"Category": "market"
 }


### PR DESCRIPTION
We have a newly created Market category for listing items which are for sale in the community. Since this kit is available to purchase (or download for free 😁 ) I think it belongs under the market tab